### PR TITLE
[BUGFIX] When finding active bans, combine IP and username with OR

### DIFF
--- a/Classes/Domain/Repository/BanRepository.php
+++ b/Classes/Domain/Repository/BanRepository.php
@@ -74,13 +74,16 @@ class BanRepository extends AbstractRepository
         $table = $this->getTable();
         $queryBuilder = $this->instantiateQueryBuilderForTable($table);
 
+        $or = $queryBuilder->expr()->orX();
+        $or->add($queryBuilder->expr()
+            ->eq('ip', $queryBuilder->createNamedParameter($ip)));
+        $or->add($queryBuilder->expr()
+            ->eq('username', $queryBuilder->createNamedParameter($username)));
+
         $queryBuilder
             ->select('*')
             ->from($table)
-            ->where(
-                $queryBuilder->expr()->eq('ip', $queryBuilder->createNamedParameter($ip)),
-                $queryBuilder->expr()->eq('username', $queryBuilder->createNamedParameter($username))
-            );
+            ->where($or);
 
         if ($bantime >= 0) {
             $queryBuilder->andWhere(


### PR DESCRIPTION
Because the ban table stores two records for IP and username, the query
to fetch them must use orX() to get a result.

Resolves: issue #5 , https://github.com/WebentwicklerAt/typo3-loginlimit/issues/5